### PR TITLE
Add curador panel UI

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,7 +16,7 @@
    ```bash
    npm run dev
    ```
-   Abre Electron y React con hot reload.
+   Abre Electron y React con hot reload. Accede al panel de curador en `http://localhost:5173/curador`.
 
 3. Build para producción:
    ```bash

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,9 +4,12 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Nunito:wght@400;700&display=swap" rel="stylesheet" />
     <title>Conversaciones con la Historia</title>
   </head>
-  <body>
+  <body class="font-sans">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "conversaciones-historia-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "lucide-react": "^0.517.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.16.0"
@@ -4372,6 +4373,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.517.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.517.0.tgz",
+      "integrity": "sha512-TQCwwbwIuVG6SSutUC2Ol6PRXcuZndqoVAnDa7S7xb/RWPaiKTvLwX7byUKeh0pUgvtFh0NZZwFIDuMSeB7Iwg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/matcher": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,17 +9,18 @@
     "electron:pack": "electron-builder --config electron/electron-builder.json"
   },
   "dependencies": {
+    "lucide-react": "^0.517.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^4.4.9",
+    "autoprefixer": "^10.4.15",
     "electron": "^28.0.0",
     "electron-builder": "^24.6.0",
-    "tailwindcss": "^3.3.3",
     "postcss": "^8.4.31",
-    "autoprefixer": "^10.4.15"
+    "tailwindcss": "^3.3.3",
+    "vite": "^4.4.9"
   }
 }

--- a/frontend/src/assets/nucleo-ludico-logo.svg
+++ b/frontend/src/assets/nucleo-ludico-logo.svg
@@ -1,0 +1,6 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="24" cy="24" r="22" stroke="#43AA8B" stroke-width="3" fill="#F1FAEE"/>
+  <circle cx="24" cy="24" r="12" fill="#1D3557"/>
+  <circle cx="24" cy="24" r="6" fill="#FFD166"/>
+  <text x="24" y="45" font-family="Nunito, Inter, sans-serif" font-size="10" fill="#1D3557" text-anchor="middle">Núcleo Lúdico</text>
+</svg>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,32 @@
+import { BookIcon, UsersIcon, SettingsIcon } from "lucide-react";
+import { NavLink } from "react-router-dom";
+
+export default function Sidebar() {
+  return (
+    <aside className="h-full w-64 bg-gradient-to-b from-primary to-blue-400 dark:from-slate-900 dark:to-blue-800 shadow-2xl flex flex-col py-6">
+      <div className="flex items-center justify-center mb-8">
+        <img src="/assets/nucleo-ludico-logo.svg" alt="Logo Núcleo Lúdico" className="h-16 w-16" />
+      </div>
+      <nav className="flex-1 flex flex-col gap-2 px-4">
+        <NavLink to="/curador" className="sidebar-link">
+          <BookIcon className="inline mr-2" /> Personajes
+        </NavLink>
+        <NavLink to="/curador/colecciones" className="sidebar-link">
+          <UsersIcon className="inline mr-2" /> Colecciones
+        </NavLink>
+        <NavLink to="/curador/ajustes" className="sidebar-link mt-auto">
+          <SettingsIcon className="inline mr-2" /> Ajustes
+        </NavLink>
+      </nav>
+      <style>{`
+        .sidebar-link {
+          display: flex; align-items: center; padding: 0.75rem 1rem; border-radius: 1rem;
+          font-weight: 500; color: #fff; transition: background 0.2s;
+        }
+        .sidebar-link.active, .sidebar-link:hover {
+          background: rgba(255, 255, 255, 0.2);
+        }
+      `}</style>
+    </aside>
+  );
+}

--- a/frontend/src/pages/PanelCurador.jsx
+++ b/frontend/src/pages/PanelCurador.jsx
@@ -1,7 +1,70 @@
+import Sidebar from "../components/Sidebar";
+import { PlusCircleIcon } from "lucide-react";
+import { Button, Card, CardHeader, CardContent } from "@/components/ui";
+
 export default function PanelCurador() {
+  // Datos mock para personajes y colecciones (luego vendrá integración backend)
+  const personajes = [
+    { id: 1, name: "Gabriela Mistral", collection: "Poetas Latinoamericanos" },
+    { id: 2, name: "Salvador Allende", collection: "Pensamiento Político" },
+  ];
+  const colecciones = [
+    "Poetas Latinoamericanos",
+    "Pensamiento Político",
+    "Científicos Humanistas",
+  ];
+
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold">Panel Curador</h1>
+    <div className="flex h-screen">
+      <Sidebar />
+      <main className="flex-1 p-8 bg-gradient-to-br from-accent/60 to-white dark:from-blue-900 dark:to-slate-900 overflow-y-auto">
+        <section className="mb-8">
+          <h1 className="text-4xl font-extrabold text-primary mb-2">
+            Bienvenido/a, Curador/a de Núcleo Lúdico
+          </h1>
+          <p className="text-lg text-gray-700 dark:text-gray-200 mb-4">
+            <strong>
+              “Tienes el poder de transformar la memoria histórica con cada personaje que curas y cada fuente que validas.”
+            </strong>
+            <br />
+            ¡Crea, edita y enriquece colecciones! Tu trabajo es fundamental para docentes y estudiantes.
+          </p>
+        </section>
+        <section>
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-2xl font-bold">Personajes recientes</h2>
+            <Button variant="outline" className="flex gap-2">
+              <PlusCircleIcon /> Nuevo personaje
+            </Button>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+            {personajes.map((p) => (
+              <Card key={p.id} className="rounded-2xl shadow-lg hover:scale-105 transition-transform">
+                <CardHeader>
+                  <span className="text-lg font-bold">{p.name}</span>
+                  <span className="block text-sm text-gray-500">{p.collection}</span>
+                </CardHeader>
+                <CardContent>
+                  <Button variant="ghost" className="text-primary">Editar</Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+        <section className="mt-8">
+          <h2 className="text-xl font-semibold mb-2">Colecciones</h2>
+          <div className="flex gap-3 flex-wrap">
+            {colecciones.map((col) => (
+              <span
+                key={col}
+                className="bg-primary/80 text-white px-4 py-2 rounded-xl shadow text-sm font-medium"
+              >
+                {col}
+              </span>
+            ))}
+          </div>
+        </section>
+      </main>
     </div>
   );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -9,6 +9,8 @@ module.exports = {
         primary: '#1D3557',
         secondary: '#457B9D',
         accent: '#F1FAEE',
+        accentGreen: '#43AA8B',
+        highlight: '#FFD166',
       },
       fontFamily: {
         sans: ['Inter', 'sans-serif'],


### PR DESCRIPTION
## Summary
- add editable logo asset
- implement sidebar navigation
- build curador dashboard page
- extend Tailwind theme with new colors
- load web fonts in index
- document running curador panel
- install lucide-react icons

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_68536e16cd948333bb6b7873d0d131f1