### PR TITLE
Add teacher dashboard module

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,10 @@ import Dashboard from './pages/Dashboard';
 import Chat from './pages/Chat';
 import PanelCurador from './pages/PanelCurador';
 import PanelAdmin from './pages/PanelAdmin';
+import PanelDocente from './pages/PanelDocente';
+import DocenteDesafios from './pages/DocenteDesafios';
+import DocenteReflexiones from './pages/DocenteReflexiones';
+import DocenteComparativa from './pages/DocenteComparativa';
 import Navbar from './components/Navbar';
 
 export default function App() {
@@ -18,6 +22,10 @@ export default function App() {
           <Route path="/chat/:characterId" element={<Chat />} />
           <Route path="/curador" element={<PanelCurador />} />
           <Route path="/admin" element={<PanelAdmin />} />
+          <Route path="/docente" element={<PanelDocente />} />
+          <Route path="/docente/desafios" element={<DocenteDesafios />} />
+          <Route path="/docente/reflexiones" element={<DocenteReflexiones />} />
+          <Route path="/docente/comparativa" element={<DocenteComparativa />} />
         </Routes>
       </div>
     </BrowserRouter>

--- a/frontend/src/components/SidebarDocente.jsx
+++ b/frontend/src/components/SidebarDocente.jsx
@@ -1,0 +1,28 @@
+import { NavLink } from "react-router-dom";
+import { UsersIcon, BookIcon, MessageCircleIcon, StarIcon, BarChartIcon } from "lucide-react";
+
+export default function SidebarDocente() {
+  return (
+    <aside className="h-full w-60 bg-gradient-to-b from-primary to-blue-400 dark:from-slate-900 dark:to-blue-800 shadow-2xl flex flex-col py-6">
+      <div className="flex items-center justify-center mb-8">
+        <img src="/assets/nucleo-ludico-logo.svg" alt="Logo Núcleo Lúdico" className="h-14 w-14" />
+      </div>
+      <nav className="flex-1 flex flex-col gap-2 px-4">
+        <NavLink to="/docente" className="sidebar-link"><BarChartIcon className="inline mr-2" /> Dashboard</NavLink>
+        <NavLink to="/docente/desafios" className="sidebar-link"><StarIcon className="inline mr-2" /> Desafíos</NavLink>
+        <NavLink to="/docente/reflexiones" className="sidebar-link"><MessageCircleIcon className="inline mr-2" /> Reflexiones</NavLink>
+        <NavLink to="/docente/personajes" className="sidebar-link"><BookIcon className="inline mr-2" /> Personajes</NavLink>
+        <NavLink to="/docente/reportes" className="sidebar-link"><UsersIcon className="inline mr-2" /> Reportes/Mensajes</NavLink>
+      </nav>
+      <style>{`
+        .sidebar-link {
+          display: flex; align-items: center; padding: 0.75rem 1rem; border-radius: 1rem;
+          font-weight: 500; color: #fff; transition: background 0.2s;
+        }
+        .sidebar-link.active, .sidebar-link:hover {
+          background: rgba(255, 255, 255, 0.2);
+        }
+      `}</style>
+    </aside>
+  );
+}

--- a/frontend/src/pages/DocenteComparativa.jsx
+++ b/frontend/src/pages/DocenteComparativa.jsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { getComparativa } from "../services/api";
+
+export default function DocenteComparativa() {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    getComparativa().then(setData);
+  }, []);
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-6">Comparativa de participación y logros</h1>
+      <div className="bg-white rounded-2xl shadow-lg p-6 mb-8">
+        <div className="h-48 flex items-end gap-6">
+          {data.map((g, i) => (
+            <div key={i} className="flex flex-col items-center">
+              <div style={{ height: g.participacion * 2 }} className="w-8 bg-blue-400 rounded-t-xl"></div>
+              <span className="mt-2 font-bold">{g.nombre}</span>
+              <span className="text-xs text-gray-500">{g.participacion} participaciones</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <table className="w-full border mt-6">
+        <thead>
+          <tr>
+            <th>Estudiante</th>
+            <th>Grupo</th>
+            <th>Participación</th>
+            <th>Logros</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.flatMap(g => g.estudiantes).map((e, i) => (
+            <tr key={i} className="border-t">
+              <td>{e.nombre}</td>
+              <td>{e.grupo}</td>
+              <td>{e.participacion}</td>
+              <td>{e.logros}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/DocenteDesafios.jsx
+++ b/frontend/src/pages/DocenteDesafios.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, Button } from "@/components/ui";
+import { PlusCircleIcon } from "lucide-react";
+import { getDesafios, crearDesafio } from "../services/api";
+
+export default function DocenteDesafios() {
+  const [desafios, setDesafios] = useState([]);
+  const [showForm, setShowForm] = useState(false);
+  const [nuevo, setNuevo] = useState({ titulo: "", descripcion: "", grupo: "", personajeId: "" });
+
+  useEffect(() => {
+    getDesafios().then(setDesafios);
+  }, []);
+
+  async function handleCrear(e) {
+    e.preventDefault();
+    await crearDesafio(nuevo);
+    setShowForm(false);
+    setNuevo({ titulo: "", descripcion: "", grupo: "", personajeId: "" });
+    setDesafios(await getDesafios());
+  }
+
+  return (
+    <div className="p-8">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-bold">Desafíos</h1>
+        <Button variant="primary" onClick={() => setShowForm(true)}>
+          <PlusCircleIcon className="inline mr-1" /> Nuevo desafío
+        </Button>
+      </div>
+      {showForm && (
+        <form className="bg-white rounded-xl shadow-lg p-6 mb-8" onSubmit={handleCrear}>
+          <h2 className="text-lg font-semibold mb-3">Crear nuevo desafío</h2>
+          <input className="input" placeholder="Título" value={nuevo.titulo} onChange={e => setNuevo({ ...nuevo, titulo: e.target.value })} required />
+          <textarea className="input" placeholder="Descripción" value={nuevo.descripcion} onChange={e => setNuevo({ ...nuevo, descripcion: e.target.value })} required />
+          <input className="input" placeholder="Grupo" value={nuevo.grupo} onChange={e => setNuevo({ ...nuevo, grupo: e.target.value })} />
+          <input className="input" placeholder="ID Personaje" value={nuevo.personajeId} onChange={e => setNuevo({ ...nuevo, personajeId: e.target.value })} />
+          <div className="flex gap-3 mt-3">
+            <Button type="button" variant="outline" onClick={() => setShowForm(false)}>Cancelar</Button>
+            <Button type="submit" variant="primary">Crear</Button>
+          </div>
+          <style>{`.input{width:100%;padding:0.75rem;margin-bottom:0.5rem;border-radius:0.75rem;border:1px solid #ccc;}`}</style>
+        </form>
+      )}
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {desafios.map((d, i) => (
+          <Card key={i}>
+            <CardHeader>
+              <span className="font-bold">{d.titulo}</span>
+            </CardHeader>
+            <CardContent>
+              <div className="text-sm text-gray-600 mb-2">{d.descripcion}</div>
+              <div className="text-xs text-gray-400">Grupo: {d.grupo || "–"} | Personaje: {d.personajeId || "–"}</div>
+              <Button variant="outline" className="mt-2">Ver entregas</Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/DocenteReflexiones.jsx
+++ b/frontend/src/pages/DocenteReflexiones.jsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, Button } from "@/components/ui";
+import { getReflexiones, enviarFeedback } from "../services/api";
+
+export default function DocenteReflexiones() {
+  const [reflexiones, setReflexiones] = useState([]);
+
+  useEffect(() => {
+    getReflexiones().then(setReflexiones);
+  }, []);
+
+  async function handleFeedback(id, texto) {
+    await enviarFeedback(id, texto);
+    setReflexiones(await getReflexiones());
+  }
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-6">Reflexiones y feedback</h1>
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {reflexiones.map((r, i) => (
+          <Card key={i}>
+            <CardHeader>
+              <span className="font-bold">{r.estudiante}</span> <span className="text-xs text-gray-400 ml-2">{r.fecha}</span>
+            </CardHeader>
+            <CardContent>
+              <div className="mb-2 text-gray-700">{r.texto}</div>
+              <div className="text-xs text-gray-400 mb-2">Desafío: {r.desafioTitulo || "–"}</div>
+              {r.feedbackAutomatico && (
+                <div className="text-green-700 text-sm mb-2">
+                  <b>Feedback automático:</b> {r.feedbackAutomatico}
+                </div>
+              )}
+              <textarea className="input" placeholder="Escribe tu feedback personalizado aquí..." onBlur={e => handleFeedback(r.id, e.target.value)} />
+              <style>{`.input{width:100%;padding:0.5rem;border-radius:0.5rem;border:1px solid #ccc;}`}</style>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/PanelDocente.jsx
+++ b/frontend/src/pages/PanelDocente.jsx
@@ -1,0 +1,109 @@
+import SidebarDocente from "../components/SidebarDocente";
+import { Card, CardContent, CardHeader, Button } from "@/components/ui";
+import { useEffect, useState } from "react";
+import { getResumenPanelDocente, getGrupos, getUltimosEventos } from "../services/api";
+import { LineChart, BarChart, UsersIcon, BookIcon, MessageCircleIcon, AwardIcon } from "lucide-react";
+
+export default function PanelDocente() {
+  const [resumen, setResumen] = useState(null);
+  const [grupos, setGrupos] = useState([]);
+  const [ultimosEventos, setUltimosEventos] = useState([]);
+
+  useEffect(() => {
+    getResumenPanelDocente().then(setResumen);
+    getGrupos().then(setGrupos);
+    getUltimosEventos().then(setUltimosEventos);
+  }, []);
+
+  return (
+    <div className="flex h-screen">
+      <SidebarDocente />
+      <main className="flex-1 p-8 bg-gradient-to-br from-accent/60 to-white dark:from-blue-900 dark:to-slate-900 overflow-y-auto">
+        <h1 className="text-4xl font-extrabold text-primary mb-4">Panel Docente</h1>
+        <p className="text-lg mb-8 text-gray-700 dark:text-gray-200">
+          Bienvenido/a, <b>educador/a crítico/a</b>. Aquí puedes monitorear el aprendizaje, crear desafíos, dar retroalimentación motivante y potenciar la memoria histórica de tus estudiantes.
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+          <Card>
+            <CardHeader>
+              <UsersIcon className="text-blue-500" /> Grupos
+            </CardHeader>
+            <CardContent>
+              <span className="text-3xl font-bold">{grupos.length}</span>
+              <div className="text-sm text-gray-500">grupos activos</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <BookIcon className="text-green-500" /> Personajes
+            </CardHeader>
+            <CardContent>
+              <span className="text-3xl font-bold">{resumen?.personajes || "–"}</span>
+              <div className="text-sm text-gray-500">habilitados</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <MessageCircleIcon className="text-yellow-500" /> Reflexiones
+            </CardHeader>
+            <CardContent>
+              <span className="text-3xl font-bold">{resumen?.reflexiones || "–"}</span>
+              <div className="text-sm text-gray-500">recibidas</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <AwardIcon className="text-indigo-500" /> Logros
+            </CardHeader>
+            <CardContent>
+              <span className="text-3xl font-bold">{resumen?.logros || "–"}</span>
+              <div className="text-sm text-gray-500">insignias entregadas</div>
+            </CardContent>
+          </Card>
+        </div>
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-2">Comparativa entre grupos</h2>
+          <div className="bg-white rounded-2xl shadow-lg p-6 mb-4">
+            <div className="h-48 flex items-center justify-center text-gray-400">
+              <BarChart className="w-20 h-20" />
+              <span className="ml-3">[Gráfico: participación por grupo]</span>
+            </div>
+          </div>
+        </section>
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold mb-2">Progreso temporal (línea de tiempo)</h2>
+          <div className="bg-white rounded-2xl shadow-lg p-6 mb-4">
+            <div className="h-48 flex items-center justify-center text-gray-400">
+              <LineChart className="w-20 h-20" />
+              <span className="ml-3">[Gráfico: evolución participación/ánimo]</span>
+            </div>
+          </div>
+        </section>
+        <section>
+          <h2 className="text-xl font-semibold mb-2">Eventos recientes y feedback</h2>
+          <ul className="divide-y divide-gray-200">
+            {ultimosEventos.map((ev, i) => (
+              <li key={i} className="py-3 flex justify-between items-center">
+                <span>
+                  <b>{ev.estudiante}</b> en <b>{ev.grupo}</b>: {ev.accion}
+                  <span className="ml-2 text-xs text-gray-500">{ev.fecha}</span>
+                </span>
+                {ev.feedbackAutomatico && (
+                  <span className="ml-2 text-green-600 text-sm font-semibold">
+                    {ev.feedbackAutomatico}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+        <section className="mt-10 flex gap-3">
+          <Button variant="primary" to="/docente/desafios">Crear desafío</Button>
+          <Button variant="outline" to="/docente/reflexiones">Revisar reflexiones</Button>
+          <Button variant="outline" to="/docente/personajes">Gestionar personajes</Button>
+          <Button variant="outline" to="/docente/reportes">Reportes y mensajes</Button>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -86,3 +86,72 @@ export async function testCharacterChat(id, message) {
   const data = await res.json();
   return data.reply;
 }
+
+// --- Servicios simulados para el panel docente ---
+export async function getResumenPanelDocente() {
+  return { personajes: 7, reflexiones: 24, logros: 15 };
+}
+
+export async function getGrupos() {
+  return [
+    { id: 1, nombre: "7A" },
+    { id: 2, nombre: "7B" },
+    { id: 3, nombre: "8A" }
+  ];
+}
+
+export async function getUltimosEventos() {
+  return [
+    { estudiante: "Camilo D.", grupo: "7A", accion: "Envío reflexión", fecha: "hace 2 h", feedbackAutomatico: "¡Excelente profundidad!" },
+    { estudiante: "Mónica R.", grupo: "7A", accion: "Completó desafío", fecha: "hace 4 h", feedbackAutomatico: "¡Sigue así, buen trabajo crítico!" },
+    { estudiante: "Sofía M.", grupo: "8A", accion: "Ganó insignia", fecha: "ayer", feedbackAutomatico: null }
+  ];
+}
+
+export async function getDesafios() {
+  return [
+    { titulo: "Debate sobre Mistral", descripcion: "¿Por qué la poesía puede ser resistencia?", grupo: "7A", personajeId: "1" }
+  ];
+}
+
+export async function crearDesafio(d) {
+  return true;
+}
+
+export async function getReflexiones() {
+  return [
+    {
+      id: 1,
+      estudiante: "Camilo D.",
+      texto: "Creo que la memoria histórica es clave para la democracia.",
+      fecha: "hoy",
+      desafioTitulo: "Debate sobre Mistral",
+      feedbackAutomatico: "¡Gran reflexión crítica, Camilo!"
+    }
+  ];
+}
+
+export async function enviarFeedback(reflexionId, texto) {
+  return true;
+}
+
+export async function getComparativa() {
+  return [
+    {
+      nombre: "7A",
+      participacion: 15,
+      estudiantes: [
+        { nombre: "Camilo D.", grupo: "7A", participacion: 7, logros: 2 },
+        { nombre: "Mónica R.", grupo: "7A", participacion: 8, logros: 3 }
+      ]
+    },
+    {
+      nombre: "8A",
+      participacion: 10,
+      estudiantes: [
+        { nombre: "Sofía M.", grupo: "8A", participacion: 5, logros: 1 },
+        { nombre: "Matías S.", grupo: "8A", participacion: 5, logros: 1 }
+      ]
+    }
+  ];
+}


### PR DESCRIPTION
## Summary
- add PanelDocente and related pages
- add Sidebar for teacher interface
- add simulated API helpers for dashboard data
- wire new routes in `App.jsx`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68537a2a413c8333b7fc1956c89246cf