### PR TITLE
Add backup utilities and packaging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,49 @@
-# Chateando con la Historia
+# Conversaciones con la Historia — APP de Escritorio
 
-Plataforma educativa para diálogo crítico con personajes históricos y científicos, potenciando el pensamiento crítico en escuelas.
+Aplicación educativa construida con Electron, React y Node.js. Funciona de forma offline y está pensada para entornos escolares.
 
-Este repositorio contiene el código del backend en Node.js y la aplicación de escritorio construida con Electron y React.
+## Estructura del repositorio
 
-- `backend/` - API REST en Node.js + Express
-- `frontend/` - Frontend de escritorio con Electron + React
-- `docker/` - Archivos para despliegue con Docker
+- **backend/** – API REST en Node.js + Express y base SQLite.
+- **frontend/** – Frontend React y scripts de Electron.
+- **docker/** – Archivos para despliegue con Docker.
+- **scripts/** – utilidades de respaldo y restauración.
+
+## Requisitos para desarrollo
+
+- Node.js 18+
+- [Ollama](https://ollama.com/download) para el motor de IA local (ejecutar `ollama pull llama3`).
+
+## Uso en desarrollo
+
+Instala dependencias de todos los paquetes:
+
+```bash
+npm install
+```
+
+Arranca backend, frontend y Electron de forma simultánea:
+
+```bash
+npm run dev
+```
+
+## Empaquetado
+
+Genera el instalador para Windows o Linux con:
+
+```bash
+npm run package:win    # Windows
+npm run package:linux  # Linux
+```
+
+Los archivos se ubicarán en `frontend/dist` y el instalador en `release/`.
+
+## Respaldo y restauración manual
+
+```bash
+node scripts/backup.js [ruta_destino]
+node scripts/restore.js [carpeta_backup]
+```
+
+La aplicación realiza un backup automático al salir y conserva varios respaldos en la carpeta *Documentos/backups_historia_auto*.

--- a/frontend/electron/main.js
+++ b/frontend/electron/main.js
@@ -1,8 +1,11 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const path = require('path');
+const { execFile } = require('child_process');
+
+let mainWindow;
 
 function createWindow() {
-  const mainWindow = new BrowserWindow({
+  mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
     minWidth: 900,
@@ -16,7 +19,48 @@ function createWindow() {
   });
 
   mainWindow.loadFile(path.join(__dirname, '../dist/index.html'));
-  // mainWindow.webContents.openDevTools();
+}
+
+ipcMain.handle('hacer-backup', async () => {
+  const { canceled, filePath } = await dialog.showSaveDialog({
+    title: 'Guardar respaldo',
+    defaultPath: path.join(app.getPath('documents'), 'backup_historia_' + new Date().toISOString().replace(/[:.]/g, '_')),
+    buttonLabel: 'Guardar Backup'
+  });
+  if (canceled) return { ok: false };
+  return new Promise((resolve) => {
+    execFile('node', [path.join(__dirname, '../scripts/backup.js'), filePath], (err, stdout, stderr) => {
+      if (err) resolve({ ok: false, error: stderr || err.message });
+      else resolve({ ok: true, msg: stdout });
+    });
+  });
+});
+
+ipcMain.handle('hacer-restore', async () => {
+  const { canceled, filePaths } = await dialog.showOpenDialog({
+    title: 'Selecciona carpeta de backup',
+    properties: ['openDirectory']
+  });
+  if (canceled || !filePaths[0]) return { ok: false };
+  return new Promise((resolve) => {
+    execFile('node', [path.join(__dirname, '../scripts/restore.js'), filePaths[0]], (err, stdout, stderr) => {
+      if (err) resolve({ ok: false, error: stderr || err.message });
+      else resolve({ ok: true, msg: stdout });
+    });
+  });
+});
+
+function backupOnExit() {
+  const dir = path.join(app.getPath('documents'), 'backups_historia_auto');
+  const target = path.join(dir, 'backup_' + new Date().toISOString().replace(/[:.]/g, '_'));
+  return new Promise((resolve) => {
+    execFile('node', [path.join(__dirname, '../scripts/backup.js'), target], (err) => {
+      if (!err && mainWindow) {
+        mainWindow.webContents.send('backup-realizado', 'Backup automático realizado al salir.');
+      }
+      resolve();
+    });
+  });
 }
 
 app.whenReady().then(() => {
@@ -24,6 +68,12 @@ app.whenReady().then(() => {
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
+});
+
+app.on('before-quit', async (e) => {
+  e.preventDefault();
+  await backupOnExit();
+  app.exit();
 });
 
 app.on('window-all-closed', () => {

--- a/frontend/electron/preload.js
+++ b/frontend/electron/preload.js
@@ -1,5 +1,10 @@
-const { contextBridge } = require('electron');
+const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  // Métodos seguros pueden ser añadidos aquí
+  backup: () => ipcRenderer.invoke('hacer-backup'),
+  restore: () => ipcRenderer.invoke('hacer-restore'),
+});
+
+ipcRenderer.on('backup-realizado', (_event, msg) => {
+  window.dispatchEvent(new CustomEvent('backup-realizado', { detail: msg }));
 });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,11 +10,11 @@ import PanelDocente from './pages/PanelDocente';
 import DocenteDesafios from './pages/DocenteDesafios';
 import DocenteReflexiones from './pages/DocenteReflexiones';
 import DocenteComparativa from './pages/DocenteComparativa';
-h0f1kp-codex/integrar-backend-con-frontend-para-panel-docente
 import DocenteResumenEstudiante from './pages/DocenteResumenEstudiante';
 import DocenteMensajesEstudiantes from './pages/DocenteMensajesEstudiantes';
-main
+import DocenteBackupRestore from './pages/DocenteBackupRestore';
 import Navbar from './components/Navbar';
+import NotificacionBackupAuto from './components/NotificacionBackupAuto';
 
 export default function App() {
   return (
@@ -34,11 +34,11 @@ export default function App() {
           <Route path="/docente/desafios" element={<DocenteDesafios />} />
           <Route path="/docente/reflexiones" element={<DocenteReflexiones />} />
           <Route path="/docente/comparativa" element={<DocenteComparativa />} />
-h0f1kp-codex/integrar-backend-con-frontend-para-panel-docente
           <Route path="/docente/estudiante/:estudianteId" element={<DocenteResumenEstudiante />} />
           <Route path="/docente/mensajes-estudiantes" element={<DocenteMensajesEstudiantes />} />
-main
+          <Route path="/docente/backup" element={<DocenteBackupRestore />} />
         </Routes>
+        <NotificacionBackupAuto />
       </div>
     </BrowserRouter>
   );

--- a/frontend/src/components/NotificacionBackupAuto.jsx
+++ b/frontend/src/components/NotificacionBackupAuto.jsx
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+export default function NotificacionBackupAuto() {
+  const [msg, setMsg] = useState('');
+  useEffect(() => {
+    const handler = (e) => setMsg(e.detail);
+    window.addEventListener('backup-realizado', handler);
+    return () => window.removeEventListener('backup-realizado', handler);
+  }, []);
+  if (!msg) return null;
+  return (
+    <div className="fixed bottom-5 right-5 bg-green-100 text-green-800 rounded-2xl px-5 py-3 shadow-lg z-50">
+      {msg}
+    </div>
+  );
+}

--- a/frontend/src/components/SidebarDocente.jsx
+++ b/frontend/src/components/SidebarDocente.jsx
@@ -12,11 +12,9 @@ export default function SidebarDocente() {
         <NavLink to="/docente/desafios" className="sidebar-link"><StarIcon className="inline mr-2" /> Desafíos</NavLink>
         <NavLink to="/docente/reflexiones" className="sidebar-link"><MessageCircleIcon className="inline mr-2" /> Reflexiones</NavLink>
         <NavLink to="/docente/personajes" className="sidebar-link"><BookIcon className="inline mr-2" /> Personajes</NavLink>
-h0f1kp-codex/integrar-backend-con-frontend-para-panel-docente
         <NavLink to="/docente/mensajes-estudiantes" className="sidebar-link"><UsersIcon className="inline mr-2" /> Mensajes</NavLink>
-
         <NavLink to="/docente/reportes" className="sidebar-link"><UsersIcon className="inline mr-2" /> Reportes/Mensajes</NavLink>
-main
+        <NavLink to="/docente/backup" className="sidebar-link"><UsersIcon className="inline mr-2" /> Backup</NavLink>
       </nav>
       <style>{`
         .sidebar-link {

--- a/frontend/src/pages/DocenteBackupRestore.jsx
+++ b/frontend/src/pages/DocenteBackupRestore.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui';
+import { DownloadIcon, UploadIcon } from 'lucide-react';
+
+export default function DocenteBackupRestore() {
+  const [msg, setMsg] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleBackup() {
+    setLoading(true);
+    setMsg('');
+    const res = await window.electronAPI.backup();
+    setLoading(false);
+    if (res.ok) setMsg('✅ Backup realizado exitosamente.');
+    else setMsg('❌ Error: ' + (res.error || 'No se pudo realizar el backup.'));
+  }
+
+  async function handleRestore() {
+    setLoading(true);
+    setMsg('');
+    const res = await window.electronAPI.restore();
+    setLoading(false);
+    if (res.ok) setMsg('✅ Restauración completada. Reinicia la aplicación.');
+    else setMsg('❌ Error: ' + (res.error || 'No se pudo restaurar.'));
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-blue-50 to-slate-100 dark:from-slate-900 dark:to-blue-900">
+      <div className="bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-8 w-full max-w-lg">
+        <h1 className="text-2xl font-bold mb-6">Respaldo y Restauración</h1>
+        <div className="flex flex-col gap-6 mb-4">
+          <Button variant="primary" onClick={handleBackup} disabled={loading} className="flex items-center gap-2">
+            <DownloadIcon /> Hacer Backup
+          </Button>
+          <Button variant="outline" onClick={handleRestore} disabled={loading} className="flex items-center gap-2">
+            <UploadIcon /> Restaurar Backup
+          </Button>
+        </div>
+        <div className="text-center mt-4 text-lg">
+          {loading && <span className="text-blue-500">Procesando...</span>}
+          {msg && <div>{msg}</div>}
+        </div>
+      </div>
+      <div className="mt-8 text-gray-600 dark:text-gray-400 max-w-md text-center">
+        El respaldo incluye tu base de datos y archivos educativos.
+        Usa “Restaurar” solo si necesitas recuperar información perdida.
+        <b className="block mt-2">Recomendación:</b> Haz un backup antes de cada actualización importante.
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -244,7 +244,6 @@ export async function getComparativa() {
     }
   ];
 }
-h0f1kp-codex/integrar-backend-con-frontend-para-panel-docente
 
 export async function getResumenEstudianteDocente(estudianteId) {
   const res = await fetch(
@@ -252,7 +251,7 @@ export async function getResumenEstudianteDocente(estudianteId) {
     { headers: authHeaders() }
   );
   if (!res.ok) throw new Error("Error al obtener resumen de estudiante");
-  return await res.json();
+    return await res.json();
 }
 
 export async function getMensajesEstudiantes() {
@@ -260,7 +259,7 @@ export async function getMensajesEstudiantes() {
     headers: authHeaders(),
   });
   if (!res.ok) throw new Error("Error al obtener mensajes");
-  return await res.json();
+    return await res.json();
 }
 
 export async function responderMensajeEstudiante(mensajeId, texto) {
@@ -273,6 +272,5 @@ export async function responderMensajeEstudiante(mensajeId, texto) {
     }
   );
   if (!res.ok) throw new Error("Error al responder mensaje");
-  return await res.json();
+    return await res.json();
 }
- main

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "conversaciones-con-la-historia",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": ["backend", "frontend"],
+  "scripts": {
+    "postinstall": "cd backend && npm install && cd ../frontend && npm install",
+    "dev": "concurrently \"npm --workspace backend start\" \"npm --workspace frontend run dev\" \"npm --workspace frontend run electron\"",
+    "build:frontend": "npm --workspace frontend run build",
+    "package:win": "npm --workspace frontend run electron:pack -- --win",
+    "package:linux": "npm --workspace frontend run electron:pack -- --linux"
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.1"
+  }
+}

--- a/scripts/backup.js
+++ b/scripts/backup.js
@@ -1,0 +1,29 @@
+/**
+ * Script de respaldo para "Conversaciones con la Historia"
+ * Copia la base de datos y carpetas esenciales a una ruta de destino.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const DB_PATH = path.resolve(__dirname, '../backend/database.sqlite');
+const RESOURCES_PATH = path.resolve(__dirname, '../backend/archivos');
+const destRoot = process.argv[2] || path.resolve(__dirname, '../backups/backup_' + new Date().toISOString().replace(/[:.]/g, '_'));
+
+if (!fs.existsSync(destRoot)) fs.mkdirSync(destRoot, { recursive: true });
+
+const dbDest = path.join(destRoot, 'database.sqlite');
+if (fs.existsSync(DB_PATH)) fs.copyFileSync(DB_PATH, dbDest);
+
+function copyDir(src, dest) {
+  if (!fs.existsSync(src)) return;
+  fs.mkdirSync(dest, { recursive: true });
+  for (const item of fs.readdirSync(src)) {
+    const srcPath = path.join(src, item);
+    const destPath = path.join(dest, item);
+    if (fs.lstatSync(srcPath).isDirectory()) copyDir(srcPath, destPath);
+    else fs.copyFileSync(srcPath, destPath);
+  }
+}
+copyDir(RESOURCES_PATH, path.join(destRoot, 'archivos'));
+
+console.log(`Backup completado en: ${destRoot}`);

--- a/scripts/restore.js
+++ b/scripts/restore.js
@@ -1,0 +1,33 @@
+/**
+ * Restaurar base de datos y archivos desde una carpeta de backup.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const sourceRoot = process.argv[2];
+if (!sourceRoot || !fs.existsSync(sourceRoot)) {
+  console.error('Debes indicar la carpeta de backup.');
+  process.exit(1);
+}
+const DB_PATH = path.resolve(__dirname, '../backend/database.sqlite');
+const RESOURCES_PATH = path.resolve(__dirname, '../backend/archivos');
+
+const dbBackup = path.join(sourceRoot, 'database.sqlite');
+if (fs.existsSync(dbBackup)) {
+  fs.copyFileSync(dbBackup, DB_PATH);
+  console.log('Base de datos restaurada.');
+}
+
+function copyDir(src, dest) {
+  if (!fs.existsSync(src)) return;
+  fs.mkdirSync(dest, { recursive: true });
+  for (const item of fs.readdirSync(src)) {
+    const srcPath = path.join(src, item);
+    const destPath = path.join(dest, item);
+    if (fs.lstatSync(srcPath).isDirectory()) copyDir(srcPath, destPath);
+    else fs.copyFileSync(srcPath, destPath);
+  }
+}
+copyDir(path.join(sourceRoot, 'archivos'), RESOURCES_PATH);
+
+console.log('Restauración completa.');


### PR DESCRIPTION
## Summary
- add workspace `package.json` with dev and package scripts
- implement backup and restore scripts
- expose backup features via Electron preload and main process
- add React UI for backup/restore and notification
- document packaging and backup instructions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853897612d48333aa59771f277ca29d